### PR TITLE
Adding topographic map for Norway

### DIFF
--- a/sources/europe/no/Kartverket-N50-topo.geojson
+++ b/sources/europe/no/Kartverket-N50-topo.geojson
@@ -1,0 +1,31 @@
+{
+        "type": "Feature",
+        "properties": {
+                "name": "Kartverket N50 topo",
+                "id": "kartverket-topo4", 
+                "type": "tms", 
+                "country_code": "NO", 
+                "description": "Topographic map N50, equivalent to Norway 1:50.000 paper map series.", 
+                "url": "http://opencache{switch:,2,3}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4&zoom={zoom}&x={x}&y={y}", 
+                "icon": "https://www.kartverket.no/Content/Images/logo-graphic-512.png", 
+                "min_zoom": 3, 
+                "max_zoom": 15, 
+                "valid_georeference": "true"
+                "attributation": {
+                        "required": true, 
+                        "text": "\u00a9 Kartverket", 
+                        "url": "https://wiki.openstreetmap.org/wiki/No:Kartverket_import"
+                }, 
+        }, 
+        "geometry": {
+                "coordinates": [[
+                        [31.904253,70.4368136],[28.4765186,71.3289643],[23.6865015,71.2514263],[16.8090601,70.0730823], 
+                        [11.1620655,67.5253903],[9.975542,64.811576],[4.2187061,62.1449966],[4.3725367,59.1871966], 
+                        [6.1743055,57.8915032],[7.932118,57.7393554],[10.777577,58.8649103],[11.7224012,58.762509], 
+                        [12.722157,60.1141506],[13.0517469,61.3493518],[12.5243921,63.6169922],[14.2382593,63.9856094], 
+                        [15.1171656,65.9016624],[18.6987085,68.3749083],[20.0610132,68.2612583],[21.0058375,68.7841518], 
+                        [25.2465601,68.3506025],[26.9384546,69.8472011],[28.7621851,69.6112133],[28.5864039,68.8556004], 
+                        [31.069314,69.5191547],[31.904253,70.4368136]  
+                ]], 
+        },      
+},


### PR DESCRIPTION
Topographic map from "Kartverket", the Norwegian Mapping Authority.

Explicit permission filed on Norwegian OSM mailing list: [Permission](https://lists.nuug.no/pipermail/kart/2014-August/004831.html)

OSM contribution page: [Kartverket contribution](https://wiki.openstreetmap.org/wiki/Contributors#Kartverket_.28Norwegian_Mapping_Authority.29)

JOSM imagery entry: [JOSM maps](https://josm.openstreetmap.de/wiki/Maps/Norway#KartverketN50topo)




